### PR TITLE
feat: expand types to allow differently typed arrays

### DIFF
--- a/src/diff/diff.ts
+++ b/src/diff/diff.ts
@@ -1,16 +1,16 @@
 import bestSubSequence from './lcs';
 
-export interface DiffData<T> {
+export interface DiffData<T, U = T> {
   removed: T[];
-  added: T[];
+  added: U[];
 }
 
-export function diff<T>(
+export function diff<T, U = T>(
   a: T[],
-  b: T[],
-  compareFunc: (ia: T, ib: T) => boolean = (ia: T, ib: T) => ia === ib,
-): DiffData<T> {
-  const ret: DiffData<T> = {
+  b: U[],
+  compareFunc: (ia: T, ib: U) => boolean = (ia: T, ib: U) => ia === (ib as unknown as T),
+): DiffData<T, U> {
+  const ret: DiffData<T, U> = {
     removed: [],
     added: [],
   };

--- a/src/diff/lcs.ts
+++ b/src/diff/lcs.ts
@@ -1,4 +1,4 @@
-function lcs<T>(a: T[], b: T[], compareFunc: (a: T, b: T) => boolean): number {
+function lcs<T, U = T>(a: T[], b: U[], compareFunc: (a: T, b: U) => boolean): number {
   const M = a.length,
     N = b.length;
   const MAX = M + N;
@@ -39,23 +39,23 @@ enum Direct {
   all = horizontal | vertical | diagonal,
 }
 
-function getSolution<T>(
+function getSolution<T, U = T>(
   a: T[],
   aStart: number,
   aEnd: number,
-  b: T[],
+  b: U[],
   bStart: number,
   bEnd: number,
   d: number,
   startDirect: Direct,
   endDirect: Direct,
-  compareFunc: (a: T, b: T) => boolean,
+  compareFunc: (a: T, b: U) => boolean,
   elementsChanged: (
     type: 'add' | 'remove' | 'same',
     a: T[],
     aStart: number,
     aEnd: number,
-    b: T[],
+    b: U[],
     bStart: number,
     bEnd: number,
   ) => void,
@@ -285,16 +285,16 @@ function getSolution<T>(
   );
 }
 
-export default function bestSubSequence<T>(
+export default function bestSubSequence<T, U = T>(
   a: T[],
-  b: T[],
-  compareFunc: (a: T, b: T) => boolean,
+  b: U[],
+  compareFunc: (a: T, b: U) => boolean,
   elementsChanged: (
     type: 'add' | 'remove' | 'same',
     a: T[],
     aStart: number,
     aEnd: number,
-    b: T[],
+    b: U[],
     bStart: number,
     bEnd: number,
   ) => void,

--- a/src/diff/same.ts
+++ b/src/diff/same.ts
@@ -1,9 +1,9 @@
 import bestSubSequence from './lcs';
 
-export default function <T>(
+export default function <T, U = T>(
   a: T[],
-  b: T[],
-  compareFunc: (ia: T, ib: T) => boolean = (ia: T, ib: T) => ia === ib,
+  b: U[],
+  compareFunc: (ia: T, ib: U) => boolean = (ia: T, ib: U) => ia === (ib as unknown as T),
 ): T[] {
   const ret: T[] = [];
   bestSubSequence(a, b, compareFunc, (type, oldArr, oldStart, oldEnd) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
+import bestSubSequence from './diff/lcs';
 import same from './diff/same';
-export { same };
+export { bestSubSequence, same };
 
 export * from './diff/diff';
 

--- a/src/test/diff.spec.ts
+++ b/src/test/diff.spec.ts
@@ -63,4 +63,16 @@ describe('Diff', () => {
       '',
     );
   });
+
+  it('Functional test on arrays of different types', () => {
+    assert.deepStrictEqual(
+      diff.diff([1, 2, 3], ['2', '3', '4'], (l, r) => {
+        assert.equal(typeof l, 'number');
+        assert.equal(typeof r, 'string');
+
+        return l.toString() === r;
+      }),
+      { added: ['4'], removed: [1] },
+    );
+  });
 });

--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -9,6 +9,41 @@ describe('Index', () => {
     assert.deepStrictEqual(diff.same([1, 2, 3], [2, 3, 4]), [2, 3]);
   });
 
+  it('bestSubSequence function in index', () => {
+    const changes: (
+      | { type: 'same' | 'remove'; values: number[] }
+      | { type: 'add'; values: string[] }
+    )[] = [];
+
+    diff.bestSubSequence(
+      [1, 2, 3],
+      ['2', '3', '4'],
+      (l, r) => {
+        assert.equal(typeof l, 'number');
+        assert.equal(typeof r, 'string');
+
+        return l.toString() === r;
+      },
+      (type, a, aStart, aEnd, b, bStart, bEnd) => {
+        assert.equal(typeof a[0], 'number');
+        assert.equal(typeof b[0], 'string');
+
+        if (type === 'add') {
+          changes.push({ type, values: b.slice(bStart, bEnd) });
+        } else {
+          changes.push({ type, values: a.slice(aStart, aEnd) });
+        }
+      },
+    );
+
+    assert.deepStrictEqual(changes, [
+      { type: 'remove', values: [1] },
+      { type: 'same', values: [2] },
+      { type: 'same', values: [3] },
+      { type: 'add', values: ['4'] },
+    ]);
+  });
+
   it('diff data and function in index', () => {
     const result: diff.DiffData<number> = {
       added: [1, 2],

--- a/src/test/same.spec.ts
+++ b/src/test/same.spec.ts
@@ -144,4 +144,16 @@ describe('Same', () => {
       ];
     assert.deepStrictEqual(same(a, b, compare), result);
   });
+
+  it('Functional test on arrays of different types', () => {
+    assert.deepStrictEqual(
+      same([1, 2, 3], ['2', '3', '4'], (l, r) => {
+        assert.equal(typeof l, 'number');
+        assert.equal(typeof r, 'string');
+
+        return l.toString() === r;
+      }),
+      [2, 3],
+    );
+  });
 });


### PR DESCRIPTION
With a comparator function, there’s not a hard requirement for the two arrays to be compatible types. The comparator tells us whether they are “equal”, and that’s enough. This will maintain the integrity between which type corresponds to what in the comparators, as well as the functions where appropriate.

This doesn’t touch `getPatch` or `applyPatch`, because patching doesn’t make sense if the types don’t match.

Related to #90